### PR TITLE
fix: unknown can be optional

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -318,7 +318,11 @@ export function parseFromProgram(
 		// This means the type of "a" in {a?:any} isn't "any | undefined"
 		// So instead we check for the questionmark to detect optional types
 		let parsedType: t.Node | undefined = undefined;
-		if (type.flags & ts.TypeFlags.Any && declaration && ts.isPropertySignature(declaration)) {
+		if (
+			(type.flags & ts.TypeFlags.Any || type.flags & ts.TypeFlags.Unknown) &&
+			declaration &&
+			ts.isPropertySignature(declaration)
+		) {
 			parsedType = declaration.questionToken
 				? t.unionNode([t.undefinedNode(), t.anyNode()])
 				: t.anyNode();

--- a/test/type-unknown/input.tsx
+++ b/test/type-unknown/input.tsx
@@ -1,0 +1,4 @@
+export default function Select(props: { value?: unknown; variant: unknown }) {
+	const { value, variant } = props;
+	return <div></div>;
+}

--- a/test/type-unknown/output.js
+++ b/test/type-unknown/output.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+function Select(props) {
+	const { value, variant } = props;
+	return <div></div>;
+}
+
+Select.propTypes = {
+	value: PropTypes.any.isRequired,
+	variant: PropTypes.any.isRequired,
+};
+
+export default Select;

--- a/test/type-unknown/output.js
+++ b/test/type-unknown/output.js
@@ -5,7 +5,7 @@ function Select(props) {
 }
 
 Select.propTypes = {
-	value: PropTypes.any.isRequired,
+	value: PropTypes.any,
 	variant: PropTypes.any.isRequired,
 };
 

--- a/test/type-unknown/output.json
+++ b/test/type-unknown/output.json
@@ -1,0 +1,13 @@
+{
+	"type": "ProgramNode",
+	"body": [
+		{
+			"type": "ComponentNode",
+			"name": "Select",
+			"types": [
+				{ "type": "PropTypeNode", "name": "value", "propType": { "type": "AnyNode" } },
+				{ "type": "PropTypeNode", "name": "variant", "propType": { "type": "AnyNode" } }
+			]
+		}
+	]
+}

--- a/test/type-unknown/output.json
+++ b/test/type-unknown/output.json
@@ -5,7 +5,14 @@
 			"type": "ComponentNode",
 			"name": "Select",
 			"types": [
-				{ "type": "PropTypeNode", "name": "value", "propType": { "type": "AnyNode" } },
+				{
+					"type": "PropTypeNode",
+					"name": "value",
+					"propType": {
+						"type": "UnionNode",
+						"types": [{ "type": "UndefinedNode" }, { "type": "AnyNode" }]
+					}
+				},
 				{ "type": "PropTypeNode", "name": "variant", "propType": { "type": "AnyNode" } }
 			]
 		}


### PR DESCRIPTION
Fixes `{ value?: unknown }` being considered `value: PropTypes.any.isRequired`.

The propTypes validator would throw runtime errors for `undefined` which is fine at the type-level. We want the type-level semantics at runtime.