### PR TITLE
chore: update repository entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
 	"files": [
 		"dist"
 	],
-	"repository": "https://github.com/merceyz/typescript-to-proptypes.git",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/merceyz/typescript-to-proptypes.git"
+	},
 	"author": "merceyz <merceyz@users.noreply.github.com>",
 	"license": "MIT",
 	"keywords": [


### PR DESCRIPTION
It seems to work on https://yarnpkg.com/package/typescript-to-proptypes
but not on https://www.npmjs.com/package/typescript-to-proptypes

This commit changes `repository` to be more like https://github.com/mui-org/material-ui/blob/926d47c94d40c44e75ac064fe9f4f537c4e062dd/packages/material-ui/package.json#L13-L16