### PR TITLE
fix: Allow non-string literals

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -214,7 +214,23 @@ export function generate(node: t.Node | t.PropTypeNode[], options: GenerateOptio
 	if (t.isUnionNode(node)) {
 		let [literals, rest] = _.partition(t.uniqueUnionTypes(node).types, t.isLiteralNode);
 
-		literals = literals.sort((a, b) => a.value.localeCompare(b.value));
+		literals = literals.sort((a, b) => {
+			const { value: valueA } = a;
+			const { value: valueB } = b;
+			// numbers ascending
+			if (typeof valueA === 'number' && typeof valueB === 'number') {
+				return valueA - valueB;
+			}
+			// numbers last
+			if (typeof valueA === 'number') {
+				return 1;
+			}
+			if (typeof valueB === 'number') {
+				return -1;
+			}
+			// sort anything else by their stringified value
+			return String(valueA).localeCompare(String(valueB));
+		});
 
 		const nodeToStringName = (obj: t.Node): string => {
 			if (t.isInstanceOfNode(obj)) {

--- a/src/types/props/literal.ts
+++ b/src/types/props/literal.ts
@@ -3,11 +3,11 @@ import { Node } from '../nodes/baseNodes';
 const typeString = 'LiteralNode';
 
 export interface LiteralNode extends Node {
-	value: any;
+	value: unknown;
 	jsDoc?: string;
 }
 
-export function literalNode(value: any, jsDoc?: string): LiteralNode {
+export function literalNode(value: unknown, jsDoc?: string): LiteralNode {
 	return {
 		type: typeString,
 		value,

--- a/test/mixed-literals/input.tsx
+++ b/test/mixed-literals/input.tsx
@@ -1,0 +1,8 @@
+interface GridProps {
+	spacing?: 'initial' | 1 | 2 | 3 | 4 | 5 | 'auto';
+}
+
+export default function Grid(props: GridProps) {
+	const { spacing } = props;
+	return <div>spacing: {spacing}</div>;
+}

--- a/test/mixed-literals/output.js
+++ b/test/mixed-literals/output.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types';
+function Grid(props) {
+	const { spacing } = props;
+	return <div>spacing: {spacing}</div>;
+}
+
+Grid.propTypes = {
+	spacing: PropTypes.oneOf(['auto', 'initial', 1, 2, 3, 4, 5]),
+};
+
+export default Grid;

--- a/test/mixed-literals/output.json
+++ b/test/mixed-literals/output.json
@@ -1,0 +1,29 @@
+{
+	"type": "ProgramNode",
+	"body": [
+		{
+			"type": "ComponentNode",
+			"name": "Grid",
+			"types": [
+				{
+					"type": "PropTypeNode",
+					"name": "spacing",
+					"propType": {
+						"type": "UnionNode",
+						"types": [
+							{ "type": "UndefinedNode" },
+							{ "type": "LiteralNode", "value": "\"initial\"" },
+							{ "type": "LiteralNode", "value": 1 },
+							{ "type": "LiteralNode", "value": 2 },
+							{ "type": "LiteralNode", "value": 3 },
+							{ "type": "LiteralNode", "value": 4 },
+							{ "type": "LiteralNode", "value": 5 },
+							{ "type": "LiteralNode", "value": "\"auto\"" }
+						]
+					},
+					"filenames": {}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Literals are now sorted by:
- numbers last, ascending
- anything else by their stringified value using localeCompare

Without this change `typescript-to-proptypes#inject` crashes.