### PR TITLE
fix: Use symbol type when there's no baseconstraint

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -376,15 +376,21 @@ export function parseFromProgram(
 			}
 		}
 
-		let type = declaration
+		const symbolType = declaration
 			? // The proptypes aren't detailed enough that we need all the different combinations
 			  // so we just pick the first and ignore the rest
-			  checker.getTypeAtLocation(declaration)
+			  checker.getTypeOfSymbolAtLocation(symbol, declaration)
 			: // The properties of Record<..., ...> don't have a declaration, but the symbol has a type property
 			  ((symbol as any).type as ts.Type);
 		// get `React.ElementType` from `C extends React.ElementType`
-		const baseConstraintOfType = checker.getBaseConstraintOfType(type);
-		type = baseConstraintOfType === undefined ? type : baseConstraintOfType;
+		const declaredType =
+			declaration !== undefined ? checker.getTypeAtLocation(declaration) : undefined;
+		const baseConstraintOfType =
+			declaredType !== undefined ? checker.getBaseConstraintOfType(declaredType) : undefined;
+		const type =
+			baseConstraintOfType !== undefined && baseConstraintOfType !== declaredType
+				? baseConstraintOfType
+				: symbolType;
 
 		if (!type) {
 			throw new Error('No types found');

--- a/test/union-props/input.d.ts
+++ b/test/union-props/input.d.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+export interface BaseProps {
+	value?: unknown;
+}
+
+export interface StandardProps extends BaseProps {
+	variant?: 'standard';
+}
+
+export interface OutlinedProps extends BaseProps {
+	variant: 'outlined';
+}
+
+export interface FilledProps extends BaseProps {
+	variant: 'filled';
+}
+
+export type TextFieldProps = StandardProps | OutlinedProps | FilledProps;
+
+export default function TextField(props: TextFieldProps): JSX.Element;

--- a/test/union-props/input.js
+++ b/test/union-props/input.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export default function TextField(props) {
+	const { value, variant } = props;
+
+	return (
+		<React.Fragment>
+			{variant}: <input value={value} />
+		</React.Fragment>
+	);
+}

--- a/test/union-props/output.js
+++ b/test/union-props/output.js
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+function TextField(props) {
+	const { value, variant } = props;
+
+	return (
+		<React.Fragment>
+			{variant}: <input value={value} />
+		</React.Fragment>
+	);
+}
+
+TextField.propTypes = {
+	value: PropTypes.any,
+	variant: PropTypes.oneOf(['standard']),
+};
+
+export default TextField;

--- a/test/union-props/output.js
+++ b/test/union-props/output.js
@@ -13,7 +13,7 @@ function TextField(props) {
 
 TextField.propTypes = {
 	value: PropTypes.any,
-	variant: PropTypes.oneOf(['standard']),
+	variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
 };
 
 export default TextField;

--- a/test/union-props/output.json
+++ b/test/union-props/output.json
@@ -12,7 +12,9 @@
 						"type": "UnionNode",
 						"types": [
 							{ "type": "UndefinedNode" },
-							{ "type": "LiteralNode", "value": "\"standard\"" }
+							{ "type": "LiteralNode", "value": "\"standard\"" },
+							{ "type": "LiteralNode", "value": "\"outlined\"" },
+							{ "type": "LiteralNode", "value": "\"filled\"" }
 						]
 					},
 					"filenames": {}

--- a/test/union-props/output.json
+++ b/test/union-props/output.json
@@ -1,0 +1,32 @@
+{
+	"type": "ProgramNode",
+	"body": [
+		{
+			"type": "ComponentNode",
+			"name": "TextField",
+			"types": [
+				{
+					"type": "PropTypeNode",
+					"name": "variant",
+					"propType": {
+						"type": "UnionNode",
+						"types": [
+							{ "type": "UndefinedNode" },
+							{ "type": "LiteralNode", "value": "\"standard\"" }
+						]
+					},
+					"filenames": {}
+				},
+				{
+					"type": "PropTypeNode",
+					"name": "value",
+					"propType": {
+						"type": "UnionNode",
+						"types": [{ "type": "UndefinedNode" }, { "type": "AnyNode" }]
+					},
+					"filenames": {}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Fixes a regression from #20 that caused discriminant unions to be too narrow.