### PR TITLE
Fix optional types not registering as such outside of TS strict mode

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,99 +10,108 @@ const prettierConfig = prettier.resolveConfig.sync(path.join(__dirname, '../.pre
 
 const testCases = glob.sync('**/input.{d.ts,ts,tsx}', { absolute: true, cwd: __dirname });
 
-// Create program for all files to speed up tests
-const program = ttp.createProgram(
-	testCases,
-	ttp.loadConfig(path.resolve(__dirname, '../tsconfig.json'))
-);
+const tsModesConfigs = {
+	'default Typescript config': '../tsconfig.json',
+	'strict mode disabled': './tsconfig.nostrict.json',
+};
 
-for (const testCase of testCases) {
-	const dirname = path.dirname(testCase);
-	const testName = dirname.substr(__dirname.length + 1);
-	const astPath = path.join(dirname, 'output.json');
-	const outputPath = path.join(dirname, 'output.js');
-	const optionsPath = path.join(dirname, 'options.ts');
-	const inputJS = path.join(dirname, 'input.js');
-
-	it(testName, () => {
-		const options: TestOptions = fs.existsSync(optionsPath) ? require(optionsPath).default : {};
-
-		const ast = ttp.parseFromProgram(testCase, program, options.parser);
-
-		//#region Check AST matches
-		// propsFilename will be different depending on where the project is on disk
-		// Manually check that it's correct and then delete it
-		const newAST = ttp.programNode(
-			ast.body.map((component) => {
-				expect(component.propsFilename).toBe(testCase);
-				return { ...component, propsFilename: undefined };
-			})
+for (const [mode, configRelativePath] of Object.entries(tsModesConfigs)) {
+	describe(`given ${mode}`, () => {
+		// Create program for all files to speed up tests
+		const program = ttp.createProgram(
+			testCases,
+			ttp.loadConfig(path.resolve(__dirname, configRelativePath))
 		);
 
-		if (fs.existsSync(astPath)) {
-			expect(newAST).toMatchObject(JSON.parse(fs.readFileSync(astPath, 'utf8')));
-		} else {
-			fs.writeFileSync(
-				astPath,
-				prettier.format(
-					JSON.stringify(newAST, (key, value) => {
-						// These are TypeScript internals that change depending on the number of symbols created during test
-						if (key === '$$id') {
-							return undefined;
-						}
-						return value;
-					}),
-					{
-						...prettierConfig,
-						filepath: astPath,
+		for (const testCase of testCases) {
+			const dirname = path.dirname(testCase);
+			const testName = dirname.substr(__dirname.length + 1);
+			const astPath = path.join(dirname, 'output.json');
+			const outputPath = path.join(dirname, 'output.js');
+			const optionsPath = path.join(dirname, 'options.ts');
+			const inputJS = path.join(dirname, 'input.js');
+
+			it(testName, () => {
+				const options: TestOptions = fs.existsSync(optionsPath) ? require(optionsPath).default : {};
+
+				const ast = ttp.parseFromProgram(testCase, program, options.parser);
+
+				//#region Check AST matches
+				// propsFilename will be different depending on where the project is on disk
+				// Manually check that it's correct and then delete it
+				const newAST = ttp.programNode(
+					ast.body.map((component) => {
+						expect(component.propsFilename).toBe(testCase);
+						return { ...component, propsFilename: undefined };
+					})
+				);
+
+				if (fs.existsSync(astPath)) {
+					expect(newAST).toMatchObject(JSON.parse(fs.readFileSync(astPath, 'utf8')));
+				} else {
+					fs.writeFileSync(
+						astPath,
+						prettier.format(
+							JSON.stringify(newAST, (key, value) => {
+								// These are TypeScript internals that change depending on the number of symbols created during test
+								if (key === '$$id') {
+									return undefined;
+								}
+								return value;
+							}),
+							{
+								...prettierConfig,
+								filepath: astPath,
+							}
+						)
+					);
+				}
+				//#endregion
+
+				let inputSource: string | null = null;
+				if (testCase.endsWith('.d.ts')) {
+					try {
+						inputSource = fs.readFileSync(inputJS, 'utf8');
+					} catch (error) {}
+				} else {
+					inputSource = ttp.ts.transpileModule(fs.readFileSync(testCase, 'utf8'), {
+						compilerOptions: {
+							target: ttp.ts.ScriptTarget.ESNext,
+							jsx: ttp.ts.JsxEmit.Preserve,
+						},
+					}).outputText;
+				}
+
+				let result = '';
+				// For d.ts files we just generate the AST
+				if (!inputSource) {
+					result = ttp.generate(ast, options.generator);
+				}
+				// For .tsx? files we transpile them and inject the proptypes
+				else {
+					const injected = ttp.inject(ast, inputSource, options.injector);
+					if (!injected) {
+						throw new Error('Injection failed');
 					}
-				)
-			);
-		}
-		//#endregion
 
-		let inputSource = null;
-		if (testCase.endsWith('.d.ts')) {
-			try {
-				inputSource = fs.readFileSync(inputJS, 'utf8');
-			} catch (error) {}
-		} else {
-			inputSource = ttp.ts.transpileModule(fs.readFileSync(testCase, 'utf8'), {
-				compilerOptions: {
-					target: ttp.ts.ScriptTarget.ESNext,
-					jsx: ttp.ts.JsxEmit.Preserve,
-				},
-			}).outputText;
-		}
+					result = injected;
+				}
 
-		let result = '';
-		// For d.ts files we just generate the AST
-		if (!inputSource) {
-			result = ttp.generate(ast, options.generator);
-		}
-		// For .tsx? files we transpile them and inject the proptypes
-		else {
-			const injected = ttp.inject(ast, inputSource, options.injector);
-			if (!injected) {
-				throw new Error('Injection failed');
-			}
+				//#region Check generated and/or injected proptypes
+				const propTypes = prettier.format(result, {
+					...prettierConfig,
+					filepath: outputPath,
+				});
 
-			result = injected;
+				if (fs.existsSync(outputPath)) {
+					expect(propTypes.replace(/\r?\n/g, '\n')).toMatch(
+						fs.readFileSync(outputPath, 'utf8').replace(/\r?\n/g, '\n')
+					);
+				} else {
+					fs.writeFileSync(outputPath, propTypes);
+				}
+				//#endregion
+			});
 		}
-
-		//#region Check generated and/or injected proptypes
-		const propTypes = prettier.format(result, {
-			...prettierConfig,
-			filepath: outputPath,
-		});
-
-		if (fs.existsSync(outputPath)) {
-			expect(propTypes.replace(/\r?\n/g, '\n')).toMatch(
-				fs.readFileSync(outputPath, 'utf8').replace(/\r?\n/g, '\n')
-			);
-		} else {
-			fs.writeFileSync(outputPath, propTypes);
-		}
-		//#endregion
 	});
 }

--- a/test/injector/should-include-filename-based/output.json
+++ b/test/injector/should-include-filename-based/output.json
@@ -1079,7 +1079,7 @@
 					"name": "children",
 					"propType": {
 						"type": "UnionNode",
-						"types": [{ "type": "ElementNode", "elementType": "node" }, { "type": "UndefinedNode" }]
+						"types": [{ "type": "UndefinedNode" }, { "type": "ElementNode", "elementType": "node" }]
 					},
 					"filenames": {}
 				},
@@ -2556,7 +2556,7 @@
 					"name": "children",
 					"propType": {
 						"type": "UnionNode",
-						"types": [{ "type": "ElementNode", "elementType": "node" }, { "type": "UndefinedNode" }]
+						"types": [{ "type": "UndefinedNode" }, { "type": "ElementNode", "elementType": "node" }]
 					},
 					"filenames": {}
 				}

--- a/test/reconcile-prop-types/output.json
+++ b/test/reconcile-prop-types/output.json
@@ -10,7 +10,7 @@
 					"name": "children",
 					"propType": {
 						"type": "UnionNode",
-						"types": [{ "type": "ElementNode", "elementType": "node" }, { "type": "UndefinedNode" }]
+						"types": [{ "type": "UndefinedNode" }, { "type": "ElementNode", "elementType": "node" }]
 					}
 				}
 			]

--- a/test/tsconfig.nostrict.json
+++ b/test/tsconfig.nostrict.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"strict": false
+	}
+}


### PR DESCRIPTION
On a project with `strict` TS config turned off, I discovered that the generated propTypes were always marked with `isRequired`

This PR fixes this and adds testing for this additional typescript config scenario.

Reviewing with whitespace changes turned off will make it easier to review `test/index.test.ts`